### PR TITLE
Fixed #46

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/description/DataDescription.java
+++ b/src/main/java/org/assertj/assertions/generator/description/DataDescription.java
@@ -12,17 +12,18 @@
  */
 package org.assertj.assertions.generator.description;
 
-import static org.apache.commons.lang3.StringUtils.remove;
-import static org.assertj.assertions.generator.util.ClassUtil.getNegativePredicateFor;
-import static org.assertj.assertions.generator.util.ClassUtil.getPredicatePrefix;
-import static org.assertj.assertions.generator.util.StringUtil.camelCaseToWords;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Ordering;
+import com.google.common.primitives.Ints;
 
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Ordering;
-import com.google.common.primitives.Ints;
+import static org.apache.commons.lang3.StringUtils.remove;
+import static org.apache.commons.lang3.StringUtils.removeStart;
+import static org.assertj.assertions.generator.util.ClassUtil.getNegativePredicateFor;
+import static org.assertj.assertions.generator.util.ClassUtil.getPredicatePrefix;
+import static org.assertj.assertions.generator.util.StringUtil.camelCaseToWords;
 
 /**
  * base class to describe a field or a property/getter
@@ -188,7 +189,7 @@ public abstract class DataDescription {
     for (String predicatePrefix : prefixesSortedByBiggerLength) {
       if (originalMember.startsWith(predicatePrefix)) {
         // get rid of prefix
-        String propertyName = remove(originalMember, predicatePrefix);
+        String propertyName = removeStart(originalMember, predicatePrefix);
         // make it human readable
         return camelCaseToWords(propertyName);
       }

--- a/src/test/java/org/assertj/assertions/generator/data/nba/Player.java
+++ b/src/test/java/org/assertj/assertions/generator/data/nba/Player.java
@@ -32,6 +32,7 @@ public class Player {
   private int reboundsPerGame;
   private String team;
   private float size;
+  private boolean isDisabled;
   private List<Player> teamMates = new ArrayList<Player>();
   private List<int[]> points = new ArrayList<int[]>();
   private String[] previousTeams = {};
@@ -41,7 +42,15 @@ public class Player {
     setTeam(team);
   }
 
-  public Name getName() {
+    public boolean isDisabled() {
+        return isDisabled;
+    }
+
+    public void setDisabled(boolean isDisabled) {
+        this.isDisabled = isDisabled;
+    }
+
+    public Name getName() {
     return name;
   }
 

--- a/src/test/resources/PlayerAssert.expected.txt
+++ b/src/test/resources/PlayerAssert.expected.txt
@@ -420,6 +420,42 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
   
 
   /**
+   * Verifies that the actual Player is disabled.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player is not disabled.
+   */
+  public PlayerAssert isDisabled() {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check
+    if (!actual.isDisabled()) {
+      failWithMessage("\nExpecting that actual Player is disabled but is not.");
+    }
+    
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player is not disabled.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player is disabled.
+   */
+  public PlayerAssert isNotDisabled() {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check
+    if (actual.isDisabled()) {
+      failWithMessage("\nExpecting that actual Player is not disabled but is.");
+    }
+    
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Player is rookie.
    * @return this assertion object.
    * @throws AssertionError - if the actual Player is not rookie.


### PR DESCRIPTION
The problem was the usage of StringUtils.remove which removes all occurences of the prefix. After refactoring to removeStart the problem is gone. 
I have extended the Player class with an boolean isDisabled property so that we have a regression test.

I have took a short look for other datatypes such as String but couldn't reproduce the problem.