### PR TITLE
not initialize the class

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
+++ b/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
@@ -231,7 +231,7 @@ public class ClassUtil {
   }
 
   private static Class<?> loadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
-    return Class.forName(className, true, classLoader);
+    return Class.forName(className, false, classLoader);
   }
 
   /**


### PR DESCRIPTION
When a class is instrumentet by e.g. jacoco and has a field with an initializer that calls a method in an instrumented class the generator fails when loading and initialize the class with 'A required class was missing while executing org.assertj:assertj-assertions-generator-maven-plugin:2.0.0:generate-assertions: org/jacoco/agent/rt/internal_b0d6a23/Offline'. From what i have seen it is not necessary to initialize the class.