### PR TITLE
Fixed some javadoc tags in the templates

### DIFF
--- a/src/main/resources/templates/has_elements_assertion_template_for_iterable.txt
+++ b/src/main/resources/templates/has_elements_assertion_template_for_iterable.txt
@@ -20,7 +20,7 @@
   }
 
   /**
-   * Verifies that the actual ${class_to_assert}'s ${property} contains <b>only<b> the given ${elementType} elements and nothing else in whatever order.
+   * Verifies that the actual ${class_to_assert}'s ${property} contains <b>only</b> the given ${elementType} elements and nothing else in whatever order.
    * @param ${property_safe} the given elements that should be contained in actual ${class_to_assert}'s ${property}.
    * @return this assertion object.
    * @throws AssertionError if the actual ${class_to_assert}'s ${property} does not contain all given ${elementType} elements.${throws_javadoc}

--- a/src/main/resources/templates/junit_soft_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/junit_soft_assertions_entry_point_class_template.txt
@@ -18,7 +18,7 @@ public class JUnitSoftAssertions implements TestRule {
   /** Collects error messages of all AssertionErrors thrown by the proxied method. */
   protected final ErrorCollector collector = new ErrorCollector();
 
-  /** Creates a new </code>{@link JUnitSoftAssertions}</code>. */
+  /** Creates a new <code>{@link JUnitSoftAssertions}</code>. */
   public JUnitSoftAssertions() {
     super();
   }

--- a/src/main/resources/templates/soft_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/soft_assertions_entry_point_class_template.txt
@@ -17,7 +17,7 @@ public class SoftAssertions {
   /** Collects error messages of all AssertionErrors thrown by the proxied method. */
   protected final ErrorCollector collector = new ErrorCollector();
 
-  /** Creates a new </code>{@link SoftAssertions}</code>. */
+  /** Creates a new <code>{@link SoftAssertions}</code>. */
   public SoftAssertions() {
   }
 


### PR DESCRIPTION
There were still a couple of erroneous javadoc tags such as
`<b>...<b>` or `</code>...</code>` in the templates.

This fixes the ones I could find.