### PR TITLE
Tests fails because of HTML errors

### DIFF
--- a/src/main/resources/templates/has_elements_assertion_template_for_iterable.txt
+++ b/src/main/resources/templates/has_elements_assertion_template_for_iterable.txt
@@ -18,6 +18,29 @@
     // return the current assertion for method chaining
     return ${myself};
   }
+  
+  /**
+   * Verifies that the actual ${class_to_assert}'s ${property} contains the given ${elementType} elements in Collection.
+   * @param ${property_safe} the given elements that should be contained in actual ${class_to_assert}'s ${property}.
+   * @return this assertion object.
+   * @throws AssertionError if the actual ${class_to_assert}'s ${property} does not contain all given ${elementType} elements.${throws_javadoc}
+   */
+  public ${self_type} has${Property}(java.util.Collection<? extends ${elementType}> ${property_safe}) ${throws}{
+    // check that actual ${class_to_assert} we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given ${elementType} collection is not null.
+    if (${property_safe} == null) {
+      failWithMessage("Expecting ${property} parameter not to be null.");
+      return ${myself}; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.get${Property}(), ${property_safe}.toArray());
+
+    // return the current assertion for method chaining
+    return ${myself};
+  }
 
   /**
    * Verifies that the actual ${class_to_assert}'s ${property} contains <b>only</b> the given ${elementType} elements and nothing else in whatever order.
@@ -40,6 +63,29 @@
   }
 
   /**
+   * Verifies that the actual ${class_to_assert}'s ${property} contains <b>only</b> the given ${elementType} elements in Collection and nothing else in whatever order.
+   * @param ${property_safe} the given elements that should be contained in actual ${class_to_assert}'s ${property}.
+   * @return this assertion object.
+   * @throws AssertionError if the actual ${class_to_assert}'s ${property} does not contain all given ${elementType} elements.${throws_javadoc}
+   */
+  public ${self_type} hasOnly${Property}(java.util.Collection<? extends ${elementType}> ${property_safe}) ${throws}{
+    // check that actual ${class_to_assert} we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given ${elementType} collection is not null.
+    if (${property_safe} == null) {
+      failWithMessage("Expecting ${property} parameter not to be null.");
+      return ${myself}; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.get${Property}(), ${property_safe}.toArray());
+
+    // return the current assertion for method chaining
+    return ${myself};
+  }
+
+  /**
    * Verifies that the actual ${class_to_assert}'s ${property} does not contain the given ${elementType} elements.
    *
    * @param ${property_safe} the given elements that should not be in actual ${class_to_assert}'s ${property}.
@@ -55,6 +101,30 @@
     
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
     Iterables.instance().assertDoesNotContain(info, actual.get${Property}(), ${property_safe});
+
+    // return the current assertion for method chaining
+    return ${myself};
+  }
+
+  /**
+   * Verifies that the actual ${class_to_assert}'s ${property} does not contain the given ${elementType} elements in Collection.
+   *
+   * @param ${property_safe} the given elements that should not be in actual ${class_to_assert}'s ${property}.
+   * @return this assertion object.
+   * @throws AssertionError if the actual ${class_to_assert}'s ${property} contains any given ${elementType} elements.${throws_javadoc}
+   */
+  public ${self_type} doesNotHave${Property}(java.util.Collection<? extends ${elementType}> ${property_safe}) ${throws}{
+    // check that actual ${class_to_assert} we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given ${elementType} collection is not null.
+    if (${property_safe} == null) {
+      failWithMessage("Expecting ${property} parameter not to be null.");
+      return ${myself}; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.get${Property}(), ${property_safe}.toArray());
 
     // return the current assertion for method chaining
     return ${myself};

--- a/src/test/resources/BeanWithOneException.expected.txt
+++ b/src/test/resources/BeanWithOneException.expected.txt
@@ -51,7 +51,7 @@ public class BeanWithOneExceptionAssert extends AbstractAssert<BeanWithOneExcept
   }
 
   /**
-   * Verifies that the actual BeanWithOneException's arrayPropertyThrowsException contains <b>only<b> the given String elements and nothing else in whatever order.
+   * Verifies that the actual BeanWithOneException's arrayPropertyThrowsException contains <b>only</b> the given String elements and nothing else in whatever order.
    * 
    * @param arrayPropertyThrowsException the given elements that should be contained in actual BeanWithOneException's arrayPropertyThrowsException.
    * @return this assertion object.
@@ -139,7 +139,7 @@ public class BeanWithOneExceptionAssert extends AbstractAssert<BeanWithOneExcept
   }
 
   /**
-   * Verifies that the actual BeanWithOneException's iterablePropertyThrowsException contains <b>only<b> the given String elements and nothing else in whatever order.
+   * Verifies that the actual BeanWithOneException's iterablePropertyThrowsException contains <b>only</b> the given String elements and nothing else in whatever order.
    * @param iterablePropertyThrowsException the given elements that should be contained in actual BeanWithOneException's iterablePropertyThrowsException.
    * @return this assertion object.
    * @throws AssertionError if the actual BeanWithOneException's iterablePropertyThrowsException does not contain all given String elements.

--- a/src/test/resources/BeanWithOneException.expected.txt
+++ b/src/test/resources/BeanWithOneException.expected.txt
@@ -137,6 +137,30 @@ public class BeanWithOneExceptionAssert extends AbstractAssert<BeanWithOneExcept
     // return the current assertion for method chaining
     return this;
   }
+  
+  /**
+   * Verifies that the actual BeanWithOneException's iterablePropertyThrowsException contains the given String elements in Collection.
+   * @param iterablePropertyThrowsException the given elements that should be contained in actual BeanWithOneException's iterablePropertyThrowsException.
+   * @return this assertion object.
+   * @throws AssertionError if the actual BeanWithOneException's iterablePropertyThrowsException does not contain all given String elements.
+   * @throws java.io.IOException if actual.getIterablePropertyThrowsException() throws one.
+   */
+  public BeanWithOneExceptionAssert hasIterablePropertyThrowsException(java.util.Collection<? extends String> iterablePropertyThrowsException) throws java.io.IOException {
+    // check that actual BeanWithOneException we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given String collection is not null.
+    if (iterablePropertyThrowsException == null) {
+      failWithMessage("Expecting iterablePropertyThrowsException parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getIterablePropertyThrowsException(), iterablePropertyThrowsException.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
 
   /**
    * Verifies that the actual BeanWithOneException's iterablePropertyThrowsException contains <b>only</b> the given String elements and nothing else in whatever order.
@@ -160,6 +184,30 @@ public class BeanWithOneExceptionAssert extends AbstractAssert<BeanWithOneExcept
   }
 
   /**
+   * Verifies that the actual BeanWithOneException's iterablePropertyThrowsException contains <b>only</b> the given String elements in Collection and nothing else in whatever order.
+   * @param iterablePropertyThrowsException the given elements that should be contained in actual BeanWithOneException's iterablePropertyThrowsException.
+   * @return this assertion object.
+   * @throws AssertionError if the actual BeanWithOneException's iterablePropertyThrowsException does not contain all given String elements.
+   * @throws java.io.IOException if actual.getIterablePropertyThrowsException() throws one.
+   */
+  public BeanWithOneExceptionAssert hasOnlyIterablePropertyThrowsException(java.util.Collection<? extends String> iterablePropertyThrowsException) throws java.io.IOException {
+    // check that actual BeanWithOneException we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given String collection is not null.
+    if (iterablePropertyThrowsException == null) {
+      failWithMessage("Expecting iterablePropertyThrowsException parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getIterablePropertyThrowsException(), iterablePropertyThrowsException.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual BeanWithOneException's iterablePropertyThrowsException does not contain the given String elements.
    *
    * @param iterablePropertyThrowsException the given elements that should not be in actual BeanWithOneException's iterablePropertyThrowsException.
@@ -176,6 +224,31 @@ public class BeanWithOneExceptionAssert extends AbstractAssert<BeanWithOneExcept
     
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
     Iterables.instance().assertDoesNotContain(info, actual.getIterablePropertyThrowsException(), iterablePropertyThrowsException);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual BeanWithOneException's iterablePropertyThrowsException does not contain the given String elements in Collection.
+   *
+   * @param iterablePropertyThrowsException the given elements that should not be in actual BeanWithOneException's iterablePropertyThrowsException.
+   * @return this assertion object.
+   * @throws AssertionError if the actual BeanWithOneException's iterablePropertyThrowsException contains any given String elements.
+   * @throws java.io.IOException if actual.getIterablePropertyThrowsException() throws one.
+   */
+  public BeanWithOneExceptionAssert doesNotHaveIterablePropertyThrowsException(java.util.Collection<? extends String> iterablePropertyThrowsException) throws java.io.IOException {
+    // check that actual BeanWithOneException we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given String collection is not null.
+    if (iterablePropertyThrowsException == null) {
+      failWithMessage("Expecting iterablePropertyThrowsException parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getIterablePropertyThrowsException(), iterablePropertyThrowsException.toArray());
 
     // return the current assertion for method chaining
     return this;

--- a/src/test/resources/JUnitSoftAssertions.expected.txt
+++ b/src/test/resources/JUnitSoftAssertions.expected.txt
@@ -19,7 +19,7 @@ public class JUnitSoftAssertions implements TestRule {
   /** Collects error messages of all AssertionErrors thrown by the proxied method. */
   protected final ErrorCollector collector = new ErrorCollector();
 
-  /** Creates a new </code>{@link JUnitSoftAssertions}</code>. */
+  /** Creates a new <code>{@link JUnitSoftAssertions}</code>. */
   public JUnitSoftAssertions() {
     super();
   }

--- a/src/test/resources/Keywords.expected.txt
+++ b/src/test/resources/Keywords.expected.txt
@@ -120,7 +120,7 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
   }
 
   /**
-   * Verifies that the actual Keywords's break contains <b>only<b> the given Object elements and nothing else in whatever order.
+   * Verifies that the actual Keywords's break contains <b>only</b> the given Object elements and nothing else in whatever order.
    * @param expectedBreak the given elements that should be contained in actual Keywords's break.
    * @return this assertion object.
    * @throws AssertionError if the actual Keywords's break does not contain all given Object elements.
@@ -226,7 +226,7 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
   }
 
   /**
-   * Verifies that the actual Keywords's case contains <b>only<b> the given Object elements and nothing else in whatever order.
+   * Verifies that the actual Keywords's case contains <b>only</b> the given Object elements and nothing else in whatever order.
    * 
    * @param expectedCase the given elements that should be contained in actual Keywords's case.
    * @return this assertion object.
@@ -403,7 +403,7 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
   }
 
   /**
-   * Verifies that the actual Keywords's default contains <b>only<b> the given String elements and nothing else in whatever order.
+   * Verifies that the actual Keywords's default contains <b>only</b> the given String elements and nothing else in whatever order.
    * @param expectedDefault the given elements that should be contained in actual Keywords's default.
    * @return this assertion object.
    * @throws AssertionError if the actual Keywords's default does not contain all given String elements.
@@ -1234,7 +1234,7 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
   }
 
   /**
-   * Verifies that the actual Keywords's switch contains <b>only<b> the given String elements and nothing else in whatever order.
+   * Verifies that the actual Keywords's switch contains <b>only</b> the given String elements and nothing else in whatever order.
    * 
    * @param expectedSwitch the given elements that should be contained in actual Keywords's switch.
    * @return this assertion object.

--- a/src/test/resources/Keywords.expected.txt
+++ b/src/test/resources/Keywords.expected.txt
@@ -118,6 +118,29 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
     // return the current assertion for method chaining
     return this;
   }
+  
+  /**
+   * Verifies that the actual Keywords's break contains the given Object elements in Collection.
+   * @param expectedBreak the given elements that should be contained in actual Keywords's break.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Keywords's break does not contain all given Object elements.
+   */
+  public KeywordsAssert hasBreak(java.util.Collection<? extends Object> expectedBreak) {
+    // check that actual Keywords we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given Object collection is not null.
+    if (expectedBreak == null) {
+      failWithMessage("Expecting break parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getBreak(), expectedBreak.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
 
   /**
    * Verifies that the actual Keywords's break contains <b>only</b> the given Object elements and nothing else in whatever order.
@@ -140,6 +163,29 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
   }
 
   /**
+   * Verifies that the actual Keywords's break contains <b>only</b> the given Object elements in Collection and nothing else in whatever order.
+   * @param expectedBreak the given elements that should be contained in actual Keywords's break.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Keywords's break does not contain all given Object elements.
+   */
+  public KeywordsAssert hasOnlyBreak(java.util.Collection<? extends Object> expectedBreak) {
+    // check that actual Keywords we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given Object collection is not null.
+    if (expectedBreak == null) {
+      failWithMessage("Expecting break parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getBreak(), expectedBreak.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Keywords's break does not contain the given Object elements.
    *
    * @param expectedBreak the given elements that should not be in actual Keywords's break.
@@ -155,6 +201,30 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
     
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
     Iterables.instance().assertDoesNotContain(info, actual.getBreak(), expectedBreak);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Keywords's break does not contain the given Object elements in Collection.
+   *
+   * @param expectedBreak the given elements that should not be in actual Keywords's break.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Keywords's break contains any given Object elements.
+   */
+  public KeywordsAssert doesNotHaveBreak(java.util.Collection<? extends Object> expectedBreak) {
+    // check that actual Keywords we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given Object collection is not null.
+    if (expectedBreak == null) {
+      failWithMessage("Expecting break parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getBreak(), expectedBreak.toArray());
 
     // return the current assertion for method chaining
     return this;
@@ -401,6 +471,30 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
     // return the current assertion for method chaining
     return this;
   }
+  
+  /**
+   * Verifies that the actual Keywords's default contains the given String elements in Collection.
+   * @param expectedDefault the given elements that should be contained in actual Keywords's default.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Keywords's default does not contain all given String elements.
+   * @throws java.io.IOException if actual.getDefault() throws one.
+   */
+  public KeywordsAssert hasDefault(java.util.Collection<? extends String> expectedDefault) throws java.io.IOException {
+    // check that actual Keywords we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given String collection is not null.
+    if (expectedDefault == null) {
+      failWithMessage("Expecting default parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getDefault(), expectedDefault.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
 
   /**
    * Verifies that the actual Keywords's default contains <b>only</b> the given String elements and nothing else in whatever order.
@@ -424,6 +518,30 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
   }
 
   /**
+   * Verifies that the actual Keywords's default contains <b>only</b> the given String elements in Collection and nothing else in whatever order.
+   * @param expectedDefault the given elements that should be contained in actual Keywords's default.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Keywords's default does not contain all given String elements.
+   * @throws java.io.IOException if actual.getDefault() throws one.
+   */
+  public KeywordsAssert hasOnlyDefault(java.util.Collection<? extends String> expectedDefault) throws java.io.IOException {
+    // check that actual Keywords we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given String collection is not null.
+    if (expectedDefault == null) {
+      failWithMessage("Expecting default parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getDefault(), expectedDefault.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Keywords's default does not contain the given String elements.
    *
    * @param expectedDefault the given elements that should not be in actual Keywords's default.
@@ -440,6 +558,31 @@ public class KeywordsAssert extends AbstractAssert<KeywordsAssert, Keywords> {
     
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
     Iterables.instance().assertDoesNotContain(info, actual.getDefault(), expectedDefault);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Keywords's default does not contain the given String elements in Collection.
+   *
+   * @param expectedDefault the given elements that should not be in actual Keywords's default.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Keywords's default contains any given String elements.
+   * @throws java.io.IOException if actual.getDefault() throws one.
+   */
+  public KeywordsAssert doesNotHaveDefault(java.util.Collection<? extends String> expectedDefault) throws java.io.IOException {
+    // check that actual Keywords we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given String collection is not null.
+    if (expectedDefault == null) {
+      failWithMessage("Expecting default parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getDefault(), expectedDefault.toArray());
 
     // return the current assertion for method chaining
     return this;

--- a/src/test/resources/PlayerAssert.expected.txt
+++ b/src/test/resources/PlayerAssert.expected.txt
@@ -96,7 +96,7 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
   }
 
   /**
-   * Verifies that the actual Player's points contains <b>only<b> the given int[] elements and nothing else in whatever order.
+   * Verifies that the actual Player's points contains <b>only</b> the given int[] elements and nothing else in whatever order.
    * @param points the given elements that should be contained in actual Player's points.
    * @return this assertion object.
    * @throws AssertionError if the actual Player's points does not contain all given int[] elements.
@@ -202,7 +202,7 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
   }
 
   /**
-   * Verifies that the actual Player's previousTeams contains <b>only<b> the given String elements and nothing else in whatever order.
+   * Verifies that the actual Player's previousTeams contains <b>only</b> the given String elements and nothing else in whatever order.
    * 
    * @param previousTeams the given elements that should be contained in actual Player's previousTeams.
    * @return this assertion object.
@@ -381,7 +381,7 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
   }
 
   /**
-   * Verifies that the actual Player's teamMates contains <b>only<b> the given Player elements and nothing else in whatever order.
+   * Verifies that the actual Player's teamMates contains <b>only</b> the given Player elements and nothing else in whatever order.
    * @param teamMates the given elements that should be contained in actual Player's teamMates.
    * @return this assertion object.
    * @throws AssertionError if the actual Player's teamMates does not contain all given Player elements.

--- a/src/test/resources/PlayerAssert.expected.txt
+++ b/src/test/resources/PlayerAssert.expected.txt
@@ -94,6 +94,29 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     // return the current assertion for method chaining
     return this;
   }
+  
+  /**
+   * Verifies that the actual Player's points contains the given int[] elements in Collection.
+   * @param points the given elements that should be contained in actual Player's points.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's points does not contain all given int[] elements.
+   */
+  public PlayerAssert hasPoints(java.util.Collection<? extends int[]> points) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given int[] collection is not null.
+    if (points == null) {
+      failWithMessage("Expecting points parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPoints(), points.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
 
   /**
    * Verifies that the actual Player's points contains <b>only</b> the given int[] elements and nothing else in whatever order.
@@ -116,6 +139,29 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
   }
 
   /**
+   * Verifies that the actual Player's points contains <b>only</b> the given int[] elements in Collection and nothing else in whatever order.
+   * @param points the given elements that should be contained in actual Player's points.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's points does not contain all given int[] elements.
+   */
+  public PlayerAssert hasOnlyPoints(java.util.Collection<? extends int[]> points) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given int[] collection is not null.
+    if (points == null) {
+      failWithMessage("Expecting points parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPoints(), points.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Player's points does not contain the given int[] elements.
    *
    * @param points the given elements that should not be in actual Player's points.
@@ -131,6 +177,30 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
     Iterables.instance().assertDoesNotContain(info, actual.getPoints(), points);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's points does not contain the given int[] elements in Collection.
+   *
+   * @param points the given elements that should not be in actual Player's points.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's points contains any given int[] elements.
+   */
+  public PlayerAssert doesNotHavePoints(java.util.Collection<? extends int[]> points) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given int[] collection is not null.
+    if (points == null) {
+      failWithMessage("Expecting points parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPoints(), points.toArray());
 
     // return the current assertion for method chaining
     return this;
@@ -379,6 +449,29 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     // return the current assertion for method chaining
     return this;
   }
+  
+  /**
+   * Verifies that the actual Player's teamMates contains the given Player elements in Collection.
+   * @param teamMates the given elements that should be contained in actual Player's teamMates.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's teamMates does not contain all given Player elements.
+   */
+  public PlayerAssert hasTeamMates(java.util.Collection<? extends Player> teamMates) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given Player collection is not null.
+    if (teamMates == null) {
+      failWithMessage("Expecting teamMates parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getTeamMates(), teamMates.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
 
   /**
    * Verifies that the actual Player's teamMates contains <b>only</b> the given Player elements and nothing else in whatever order.
@@ -401,6 +494,29 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
   }
 
   /**
+   * Verifies that the actual Player's teamMates contains <b>only</b> the given Player elements in Collection and nothing else in whatever order.
+   * @param teamMates the given elements that should be contained in actual Player's teamMates.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's teamMates does not contain all given Player elements.
+   */
+  public PlayerAssert hasOnlyTeamMates(java.util.Collection<? extends Player> teamMates) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given Player collection is not null.
+    if (teamMates == null) {
+      failWithMessage("Expecting teamMates parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getTeamMates(), teamMates.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Player's teamMates does not contain the given Player elements.
    *
    * @param teamMates the given elements that should not be in actual Player's teamMates.
@@ -416,6 +532,30 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
     Iterables.instance().assertDoesNotContain(info, actual.getTeamMates(), teamMates);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's teamMates does not contain the given Player elements in Collection.
+   *
+   * @param teamMates the given elements that should not be in actual Player's teamMates.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's teamMates contains any given Player elements.
+   */
+  public PlayerAssert doesNotHaveTeamMates(java.util.Collection<? extends Player> teamMates) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given Player collection is not null.
+    if (teamMates == null) {
+      failWithMessage("Expecting teamMates parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getTeamMates(), teamMates.toArray());
 
     // return the current assertion for method chaining
     return this;

--- a/src/test/resources/SoftAssertions.expected.txt
+++ b/src/test/resources/SoftAssertions.expected.txt
@@ -18,7 +18,7 @@ public class SoftAssertions {
   /** Collects error messages of all AssertionErrors thrown by the proxied method. */
   protected final ErrorCollector collector = new ErrorCollector();
 
-  /** Creates a new </code>{@link SoftAssertions}</code>. */
+  /** Creates a new <code>{@link SoftAssertions}</code>. */
   public SoftAssertions() {
   }
 

--- a/src/test/resources/TeamAssert.expected.txt
+++ b/src/test/resources/TeamAssert.expected.txt
@@ -96,7 +96,7 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
   }
 
   /**
-   * Verifies that the actual Team's oldNames contains <b>only<b> the given String elements and nothing else in whatever order.
+   * Verifies that the actual Team's oldNames contains <b>only</b> the given String elements and nothing else in whatever order.
    * 
    * @param oldNames the given elements that should be contained in actual Team's oldNames.
    * @return this assertion object.
@@ -180,7 +180,7 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
   }
 
   /**
-   * Verifies that the actual Team's players contains <b>only<b> the given org.assertj.assertions.generator.data.nba.Player elements and nothing else in whatever order.
+   * Verifies that the actual Team's players contains <b>only</b> the given org.assertj.assertions.generator.data.nba.Player elements and nothing else in whatever order.
    * @param players the given elements that should be contained in actual Team's players.
    * @return this assertion object.
    * @throws AssertionError if the actual Team's players does not contain all given org.assertj.assertions.generator.data.nba.Player elements.
@@ -263,7 +263,7 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
   }
 
   /**
-   * Verifies that the actual Team's points contains <b>only<b> the given int[] elements and nothing else in whatever order.
+   * Verifies that the actual Team's points contains <b>only</b> the given int[] elements and nothing else in whatever order.
    * @param points the given elements that should be contained in actual Team's points.
    * @return this assertion object.
    * @throws AssertionError if the actual Team's points does not contain all given int[] elements.

--- a/src/test/resources/TeamAssert.expected.txt
+++ b/src/test/resources/TeamAssert.expected.txt
@@ -178,6 +178,29 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
     // return the current assertion for method chaining
     return this;
   }
+  
+  /**
+   * Verifies that the actual Team's players contains the given org.assertj.assertions.generator.data.nba.Player elements in Collection.
+   * @param players the given elements that should be contained in actual Team's players.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Team's players does not contain all given org.assertj.assertions.generator.data.nba.Player elements.
+   */
+  public TeamAssert hasPlayers(java.util.Collection<? extends org.assertj.assertions.generator.data.nba.Player> players) {
+    // check that actual Team we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given org.assertj.assertions.generator.data.nba.Player collection is not null.
+    if (players == null) {
+      failWithMessage("Expecting players parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.players, players.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
 
   /**
    * Verifies that the actual Team's players contains <b>only</b> the given org.assertj.assertions.generator.data.nba.Player elements and nothing else in whatever order.
@@ -200,6 +223,29 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
   }
 
   /**
+   * Verifies that the actual Team's players contains <b>only</b> the given org.assertj.assertions.generator.data.nba.Player elements in Collection and nothing else in whatever order.
+   * @param players the given elements that should be contained in actual Team's players.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Team's players does not contain all given org.assertj.assertions.generator.data.nba.Player elements.
+   */
+  public TeamAssert hasOnlyPlayers(java.util.Collection<? extends org.assertj.assertions.generator.data.nba.Player> players) {
+    // check that actual Team we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given org.assertj.assertions.generator.data.nba.Player collection is not null.
+    if (players == null) {
+      failWithMessage("Expecting players parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.players, players.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Team's players does not contain the given org.assertj.assertions.generator.data.nba.Player elements.
    *
    * @param players the given elements that should not be in actual Team's players.
@@ -215,6 +261,30 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
     
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
     Iterables.instance().assertDoesNotContain(info, actual.players, players);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Team's players does not contain the given org.assertj.assertions.generator.data.nba.Player elements in Collection.
+   *
+   * @param players the given elements that should not be in actual Team's players.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Team's players contains any given org.assertj.assertions.generator.data.nba.Player elements.
+   */
+  public TeamAssert doesNotHavePlayers(java.util.Collection<? extends org.assertj.assertions.generator.data.nba.Player> players) {
+    // check that actual Team we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given org.assertj.assertions.generator.data.nba.Player collection is not null.
+    if (players == null) {
+      failWithMessage("Expecting players parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.players, players.toArray());
 
     // return the current assertion for method chaining
     return this;
@@ -261,6 +331,29 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
     // return the current assertion for method chaining
     return this;
   }
+  
+  /**
+   * Verifies that the actual Team's points contains the given int[] elements in Collection.
+   * @param points the given elements that should be contained in actual Team's points.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Team's points does not contain all given int[] elements.
+   */
+  public TeamAssert hasPoints(java.util.Collection<? extends int[]> points) {
+    // check that actual Team we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given int[] collection is not null.
+    if (points == null) {
+      failWithMessage("Expecting points parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.points, points.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
 
   /**
    * Verifies that the actual Team's points contains <b>only</b> the given int[] elements and nothing else in whatever order.
@@ -283,6 +376,29 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
   }
 
   /**
+   * Verifies that the actual Team's points contains <b>only</b> the given int[] elements in Collection and nothing else in whatever order.
+   * @param points the given elements that should be contained in actual Team's points.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Team's points does not contain all given int[] elements.
+   */
+  public TeamAssert hasOnlyPoints(java.util.Collection<? extends int[]> points) {
+    // check that actual Team we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given int[] collection is not null.
+    if (points == null) {
+      failWithMessage("Expecting points parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.points, points.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Team's points does not contain the given int[] elements.
    *
    * @param points the given elements that should not be in actual Team's points.
@@ -298,6 +414,30 @@ public class TeamAssert extends AbstractAssert<TeamAssert, Team> {
     
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
     Iterables.instance().assertDoesNotContain(info, actual.points, points);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Team's points does not contain the given int[] elements in Collection.
+   *
+   * @param points the given elements that should not be in actual Team's points.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Team's points contains any given int[] elements.
+   */
+  public TeamAssert doesNotHavePoints(java.util.Collection<? extends int[]> points) {
+    // check that actual Team we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given int[] collection is not null.
+    if (points == null) {
+      failWithMessage("Expecting points parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+    
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.points, points.toArray());
 
     // return the current assertion for method chaining
     return this;


### PR DESCRIPTION
Hello,

The first commit patches the test.
The second add three variations for Iterable assert (because I was using a Set, I did not want to pass each items separately or even by using toArray in my test).

Regards,
@glhez