### PR TITLE
Use a more restrictive Java regexp to match class name.

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
+++ b/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
@@ -81,7 +81,7 @@ public class BaseAssertionGenerator implements AssertionGenerator, AssertionsEnt
   // used to infer the class name from the entry point custom template (specially if the template is custom)
   // - [\s]*    : any number of white space character
   // - \b(.*)\b : capture word
-  private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("public class[\\s]+\\b(.*)\\b");
+  private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("public class[\\s]+(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)\\b");
 
   /**
    * Creates a new </code>{@link BaseAssertionGenerator}</code> with default templates directory.

--- a/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
+++ b/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
@@ -81,7 +81,17 @@ public class BaseAssertionGenerator implements AssertionGenerator, AssertionsEnt
   // used to infer the class name from the entry point custom template (specially if the template is custom)
   // - [\s]*    : any number of white space character
   // - \b(.*)\b : capture word
-  private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("public class[\\s]+(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)\\b");
+  /**
+   * This regexp shall match a java class's name inside an user template.
+   * <p>
+   * For this, we use the two character class {@code javaJavaIdentifierStart} and {@code javaJavaIdentifierPart} to match
+   * a valid name.
+   *
+   * @see java.util.regex.Pattern
+   * @see Character#isJavaIdentifierStart
+   * @see Character#isJavaIdentifierPart
+   */
+  private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("public class[\\s]+(?<CLASSNAME>\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)\\b");
 
   /**
    * Creates a new </code>{@link BaseAssertionGenerator}</code> with default templates directory.
@@ -289,7 +299,7 @@ public class BaseAssertionGenerator implements AssertionGenerator, AssertionsEnt
     // expecting the class name to be here : "class <class name> "
     Matcher classNameMatcher = CLASS_NAME_PATTERN.matcher(assertionsEntryPointFileContent);
     // if we find a match return it
-    if (classNameMatcher.find()) return classNameMatcher.group(1)+ ".java";
+    if (classNameMatcher.find()) return classNameMatcher.group("CLASSNAME")+ ".java";
     // otherwise use the default name
     return assertionsEntryPointType.getFileName();
   }

--- a/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
+++ b/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
@@ -87,9 +87,9 @@ public class BaseAssertionGenerator implements AssertionGenerator, AssertionsEnt
    * <i>Description of the pattern:</i>
    * 
    * <ol>
-   * <li><code>public class[\\s]+</code> the "public class" with a set of whitespace (either tabs, space or new lines).</li>
-   * <li><code>(?&llt;CLASSNAME&gt;[...])</code> create a named group that would match a Java identifier (here the class name).</li>
-   * <li><code>\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*</code> match said identifieir using character class.</li>
+   * <li><code>public class[\\s]+</code> the "public class" followed by one or more whitespace (either tabs, space or new lines).</li>
+   * <li><code>(?&lt;CLASSNAME&gt;...)</code> create a named group that would match a Java identifier (here the class name).</li>
+   * <li><code>\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*</code> match said identifier using character class.</li>
    * </ol>
    *
    * @see java.util.regex.Pattern

--- a/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
+++ b/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
@@ -78,14 +78,19 @@ public class BaseAssertionGenerator implements AssertionGenerator, AssertionsEnt
   private String targetBaseDirectory = ".";
   private TemplateRegistry templateRegistry;// the pattern to search for
 
-  // used to infer the class name from the entry point custom template (specially if the template is custom)
-  // - [\s]*    : any number of white space character
-  // - \b(.*)\b : capture word
   /**
    * This regexp shall match a java class's name inside an user template.
    * <p>
    * For this, we use the two character class {@code javaJavaIdentifierStart} and {@code javaJavaIdentifierPart} to match
    * a valid name.
+   * <p>
+   * <i>Description of the pattern:</i>
+   * 
+   * <ol>
+   * <li><code>public class[\\s]+</code> the "public class" with a set of whitespace (either tabs, space or new lines).</li>
+   * <li><code>(?&llt;CLASSNAME&gt;[...])</code> create a named group that would match a Java identifier (here the class name).</li>
+   * <li><code>\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*</code> match said identifieir using character class.</li>
+   * </ol>
    *
    * @see java.util.regex.Pattern
    * @see Character#isJavaIdentifierStart


### PR DESCRIPTION
The regexp found in the `BaseAssertionGenerator` tries to match the Java class name. However, it read too much thing: 

```
public class SoftAssertions extends org.assertj.core.api.SoftAssertions {
-------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The change to the regexp will ensure that we read only a valid java identifier, compromised of two part (see [Character.isJavaIdentifierStart](https://docs.oracle.com/javase/7/docs/api/java/lang/Character.html#isJavaIdentifierStart(char)).

The `\b` before is useless, as we are expecting space before. 

Note:  this is required for the unit test of maven plugin to work (I'll do another PR about that).



