### PR TITLE
Backports from 3de4c3b26c1 - Fixes #105

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
+++ b/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
@@ -466,11 +466,11 @@ public class BaseAssertionGenerator implements AssertionGenerator, AssertionsEnt
   private String assertionContentForField(FieldDescription field, ClassDescription classDescription) {
     final String fieldName = field.getName();
     final String fieldNameCap = capitalize(field.getName());
-    if (classDescription.getGettersDescriptions().contains(new GetterDescription(fieldName, "get" + fieldNameCap,
-                                                                                 field.getTypeDescription(),
-                                                                                 Collections.<TypeName> emptyList()))) {
+    
+    if (classDescription.findGetterDescriptionForField(field) != null) {
       return "";
     }
+
     String assertionContent = baseAssertionContentFor(field, classDescription);
 
     // we reuse template for properties to have consistent assertions for property and field but change the way we get

--- a/src/main/java/org/assertj/assertions/generator/description/ClassDescription.java
+++ b/src/main/java/org/assertj/assertions/generator/description/ClassDescription.java
@@ -12,9 +12,12 @@
  */
 package org.assertj.assertions.generator.description;
 
-import java.util.Collection;
-import java.util.Set;
-import java.util.TreeSet;
+import static org.assertj.assertions.generator.util.ClassUtil.propertyNameOf;
+
+import java.util.*;
+
+import org.apache.commons.lang3.StringUtils;
+import org.assertj.assertions.generator.util.ClassUtil;
 
 /**
  * 
@@ -128,5 +131,40 @@ public class ClassDescription implements Comparable<ClassDescription> {
 
   public void setSuperType(Class<?> superType) {
     this.superType = superType;
+  }
+
+  public GetterDescription findGetterDescriptionForField(FieldDescription base) {
+    // Build a map for better look-up
+    Map<String, GetterDescription> fieldMap = new HashMap<>();
+    for (GetterDescription getter: this.gettersDescriptions) {
+      fieldMap.put(getter.getOriginalMember(), getter);
+    }
+    for (GetterDescription getter: this.declaredGettersDescriptions) {
+      fieldMap.put(getter.getOriginalMember(), getter);
+    }
+
+    final String capName = StringUtils.capitalize(propertyNameOf(base.getName()));
+    if (base.getTypeDescription().isBoolean()) {
+      // deal with predicates
+      for (String prefix: ClassUtil.PREDICATE_PREFIXES.keySet()) {
+        String propName = prefix + capName;
+
+        GetterDescription getterDesc = fieldMap.get(propName);
+        if (getterDesc != null) {
+          return getterDesc;
+        }
+      }
+    } else {
+
+      String propName = "get" + capName;
+
+      GetterDescription getterDesc = fieldMap.get(propName);
+      if (getterDesc != null) {
+        return getterDesc;
+      }
+    }
+
+    // wasn't found
+    return null;
   }
 }

--- a/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
+++ b/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
@@ -21,15 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Array;
-import java.lang.reflect.Field;
-import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.lang.reflect.WildcardType;
+import java.lang.reflect.*;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -238,28 +230,49 @@ public class ClassUtil {
   /**
    * Returns the property name of given getter method, examples :
    * <p/>
-   * 
+   *
    * <pre>
    * getName -> name
    * </pre>
    * <p/>
-   * 
+   *
    * <pre>
    * isMostValuablePlayer -> mostValuablePlayer
    * </pre>
    *
-   * @param getter getter method to deduce property from.
+   * @param member getter method to deduce property from.
    * @return the property name of given getter method
    */
-  public static String propertyNameOf(Method getter) {
-    String methodName = getter.getName();
-    String prefixToRemove = isPredicate(getter) ? IS_PREFIX : GET_PREFIX;
-    int pos = methodName.indexOf(prefixToRemove);
+  public static String propertyNameOf(Member member) {
+    return propertyNameOf(member.getName());
+  }
+
+  /**
+   * Returns the property name of given getter method, examples :
+   * <p/>
+   *
+   * <pre>
+   * getName -> name
+   * </pre>
+   * <p/>
+   *
+   * <pre>
+   * isMostValuablePlayer -> mostValuablePlayer
+   * </pre>
+   *
+   * @param memberName name of getter or field
+   * @return the property name of field or method
+   */
+  public static String propertyNameOf(String memberName) {
+    String predicatePrefix = getPredicatePrefix(memberName);
+    String prefixToRemove = predicatePrefix != null ? predicatePrefix : GET_PREFIX;
+
+    int pos = memberName.indexOf(prefixToRemove);
     if (pos != StringUtils.INDEX_NOT_FOUND) {
-      String propertyWithCapitalLetter = methodName.substring(pos + prefixToRemove.length());
+      String propertyWithCapitalLetter = memberName.substring(pos + prefixToRemove.length());
       return uncapitalize(propertyWithCapitalLetter);
     } else {
-      return methodName;
+      return memberName;
     }
   }
 
@@ -308,7 +321,7 @@ public class ClassUtil {
 
   static private final Pattern PREFIX_PATTERN;
 
-  static private final Map<String, String> PREDICATE_PREFIXES;
+  static public final Map<String, String> PREDICATE_PREFIXES;
 
   static private final Comparator<String> LONGEST_TO_SHORTEST = new Comparator<String>() {
     @Override

--- a/src/test/java/org/assertj/assertions/generator/data/FieldPropertyClash.java
+++ b/src/test/java/org/assertj/assertions/generator/data/FieldPropertyClash.java
@@ -16,8 +16,15 @@ package org.assertj.assertions.generator.data;
  * This is a class with properties that clash with public fields.
  */
 public class FieldPropertyClash {
-  public String string;
-  public String getString() {
-	return "";
-  }
+    public String string;
+    public String getString() {
+        return "";
+    }
+
+    // joel-costigliola/assertj-assertions-generator#105
+    // Predicate properties were not properly discerned vs non-predicate
+    public boolean isBoolean;
+    public boolean isBoolean() { return false; }
+
+    public boolean isNotBoolean() { return false; }
 }

--- a/src/test/resources/FieldPropertyClash.expected.txt
+++ b/src/test/resources/FieldPropertyClash.expected.txt
@@ -51,5 +51,42 @@ public class FieldPropertyClashAssert extends AbstractObjectAssert<FieldProperty
     return this;
   }
 
+  /**
+   * Verifies that the actual FieldPropertyClash is boolean.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual FieldPropertyClash is not boolean.
+   */
+  public FieldPropertyClashAssert isBoolean() {
+    // check that actual FieldPropertyClash we want to make assertions on is not null.
+    isNotNull();
+
+    // check
+    if (!actual.isBoolean()) {
+      failWithMessage("\nExpecting that actual FieldPropertyClash is boolean but is not.");
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual FieldPropertyClash is not boolean.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual FieldPropertyClash is boolean.
+   */
+  public FieldPropertyClashAssert isNotBoolean() {
+    // check that actual FieldPropertyClash we want to make assertions on is not null.
+    isNotNull();
+
+    // check
+    if (!actual.isNotBoolean()) {
+      failWithMessage("\nExpecting that actual FieldPropertyClash is not boolean but is.");
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+
 
 }


### PR DESCRIPTION
Backport of 3de4c3b.

* Added `findGetterDescriptionForField(FieldDescription base)` to check against all known prefixes for methods that clash
* Extended test case for FieldPropertyClash to include predicate case

Fun fact: The current master branch fails on windows, I had to use a vagrant machine to test this. 😢 

Fixes #105. 