### PR TITLE
Fix unit test failing because of use of '\n'

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
+++ b/src/main/java/org/assertj/assertions/generator/BaseAssertionGenerator.java
@@ -463,7 +463,7 @@ public class BaseAssertionGenerator implements AssertionGenerator, AssertionsEnt
     SortedSet<ClassDescription> sortedClassDescriptionSet = new TreeSet<>(classDescriptionSet);
     // generate for each classDescription the entry point method, e.g. assertThat(MyClass) or then(MyClass)
     StringBuilder allAssertThatsContentBuilder = new StringBuilder();
-    final char lineSeparator = '\n';
+    final String lineSeparator = System.lineSeparator();
     for (ClassDescription classDescription : sortedClassDescriptionSet) {
       String assertionEntryPointMethodContent = assertionEntryPointMethodTemplate.getContent();
       // resolve class assert (ex: PlayerAssert)

--- a/src/test/java/org/assertj/assertions/generator/AssertionGeneratorTest.java
+++ b/src/test/java/org/assertj/assertions/generator/AssertionGeneratorTest.java
@@ -51,7 +51,7 @@ import static org.assertj.core.api.Assertions.*;
 
 @RunWith(Theories.class)
 public class AssertionGeneratorTest implements NestedClassesTest, BeanWithExceptionsTest {
-  private static final String LINE_SEPARATOR = "\n";
+  private static final String LINE_SEPARATOR = System.lineSeparator();
   private static final Logger logger = LoggerFactory.getLogger(AssertionGeneratorTest.class);
   private ClassToClassDescriptionConverter converter;
   private BaseAssertionGenerator assertionGenerator;


### PR DESCRIPTION
There was some unit test failing because of line ending differences.
I fixed this by using System.lineSeparator() but a real (long term) fix would be to fix all test as to ignore ending separator (and probably other ignorable characters, such as spaces/tabs at end of line).