### PR TITLE
Make standard assertions entry point class extend AssertJ Assertions

### DIFF
--- a/src/main/resources/templates/standard_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/standard_assertions_entry_point_class_template.txt
@@ -5,7 +5,7 @@ package ${package};
  * type-specific assertion objects.
  */
 @javax.annotation.Generated(value="assertj-assertions-generator")
-public class Assertions {
+public class Assertions extends org.assertj.core.api.Assertions {
 ${all_assertions_entry_points}
   /**
    * Creates a new <code>{@link Assertions}</code>.

--- a/src/test/resources/Assertions.expected.txt
+++ b/src/test/resources/Assertions.expected.txt
@@ -5,7 +5,7 @@ package com.google.common.base;
  * type-specific assertion objects.
  */
 @javax.annotation.Generated(value="assertj-assertions-generator")
-public class Assertions {
+public class Assertions extends org.assertj.core.api.Assertions {
 
   /**
    * Creates a new instance of <code>{@link com.google.common.base.OptionalAssert}</code>.

--- a/src/test/resources/AssertionsForClassesWithSameName.expected.txt
+++ b/src/test/resources/AssertionsForClassesWithSameName.expected.txt
@@ -5,7 +5,7 @@ package org;
  * type-specific assertion objects.
  */
 @javax.annotation.Generated(value="assertj-assertions-generator")
-public class Assertions {
+public class Assertions extends org.assertj.core.api.Assertions {
 
   /**
    * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.TeamAssert}</code>.

--- a/src/test/resources/AssertionsWithCustomPackage.expected.txt
+++ b/src/test/resources/AssertionsWithCustomPackage.expected.txt
@@ -5,7 +5,7 @@ package my.custom.package;
  * type-specific assertion objects.
  */
 @javax.annotation.Generated(value="assertj-assertions-generator")
-public class Assertions {
+public class Assertions extends org.assertj.core.api.Assertions {
 
   /**
    * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.


### PR DESCRIPTION
The generated standard assertions entry point class now extends
org.assertj.core.api.Assertions which allows for an easier importing of
assertions. This pattern is recommended here:

http://joel-costigliola.github.io/assertj/assertj-core-custom-assertions.html#single-assertion-entry-point

I know that it is only a template change and users could change this themselves easily. However, I am a big fan of useful default configurations. As far as I can tell, the change does not break anything for users and it is a big plus because now, you only ever have to import one Assertions class.